### PR TITLE
購入機能実装後の商品情報編集機能実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,8 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_item, only: [:show, :edit, :update, :destroy, :move_to_index]
+  before_action :set_item, only: [:show, :edit, :update, :destroy, :move_to_index, :move_to_top]
   before_action :move_to_index, only: [:edit]
+  before_action :move_to_top, only: [:edit]
 
   def index
     @items = Item.all.order("created_at DESC")
@@ -55,6 +56,12 @@ class ItemsController < ApplicationController
   def move_to_index
     unless current_user.id == @item.user_id
       redirect_to action: :index
+    end
+  end
+
+  def move_to_top
+    if @item.order.present?
+      redirect_to root_path
     end
   end
 


### PR DESCRIPTION
# What
購入機能実装後の商品情報編集機能実装

# Why
購入機能実装後の商品情報編集機能実装のため

### 出品者・出品者以外にかかわらず、ログイン状態のユーザーが、URLを直接入力して売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移すること(出品者)

https://gyazo.com/f8ada84111958f514713903957e2a47a

### 出品者・出品者以外にかかわらず、ログイン状態のユーザーが、URLを直接入力して売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移すること(出品者以外)

https://gyazo.com/0afb376c6ea243c1cd54127251335cf8
