### PR TITLE
購入機能実装後の商品詳細表示機能実装

### DIFF
--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,7 +25,7 @@
       </span>
     </div>
 
-  <% if user_signed_in? && current_user.id == @item.user.id %>
+  <% if (user_signed_in? && current_user.id == @item.user.id) && @item.order.present? == false %>
     <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,12 +25,14 @@
       </span>
     </div>
 
-  <% if (user_signed_in? && current_user.id == @item.user.id) && @item.order.present? == false %>
-    <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
-  <% elsif user_signed_in? && current_user.id != @item.user.id %>
-    <%= link_to '購入画面に進む', item_orders_path(@item.id),class:"item-red-btn"%>
+  <% if user_signed_in? && @item.order.present? == false %>
+    <% if current_user.id == @item.user.id %>
+      <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
+    <% else %>
+      <%= link_to '購入画面に進む', item_orders_path(@item.id),class:"item-red-btn"%>
+    <% end %>
   <% end %>
 
     <div class="item-explain-box">


### PR DESCRIPTION
# What
購入機能実装後の商品詳細表示機能実装

# Why
購入機能実装後の商品詳細表示機能実装のため

### ログイン状態の出品者でも、売却済みの商品に対しては「編集・削除ボタン」が表示されないこと
https://gyazo.com/29ba3c294c63fd3423f1ca5862596872